### PR TITLE
Creating an EC2 and spot instance module

### DIFF
--- a/terraform/aws/examples/ec2/main.tf
+++ b/terraform/aws/examples/ec2/main.tf
@@ -1,21 +1,21 @@
 module "vpc" {
-  source                                  = "../../modules/vpc"
-  name_prefix                             = "qburst"
-  ipv4_primary_cidr_block                 = "10.16.0.0/16"
-  ipv4_additional_cidr_block_associations = ["10.20.0.0/16", "10.21.0.0/16"]
-  public_subnets_cidr                     = ["10.20.0.0/20", "10.20.16.0/20"]
-  private_subnets_cidr                    = ["10.21.0.0/20"]
-  availability_zones                      = ["ap-south-1a", "ap-south-1b"]
+  source                  = "../../modules/vpc"
+  name_prefix             = "qburst"
+  ipv4_primary_cidr_block = "10.16.0.0/16"
+  public_subnets_cidr     = ["10.16.1.0/24", "10.16.2.0/24"]
+  private_subnets_cidr    = ["10.16.12.0/24"]
+  availability_zones      = ["ap-south-1a", "ap-south-1b"]
 }
 
-module "ec2" {
+module "ec2-private" {
   source            = "../../modules/ec2"
+  instance_name     = "ec2-private"
   vpc_id            = module.vpc.vpc_id
   subnet_ids        = module.vpc.private_subnet_ids
   ssh_allowed_ip    = ["0.0.0.0/0"]
   ssh_allowed_ports = [22]
 
-  instance_count = 3
+  instance_count = 1
   ami            = "ami-099b3d23e336c2e83"
   instance_type  = "t2.nano"
 
@@ -32,4 +32,15 @@ module "ec2" {
   ebs_volume_size    = 30
 
   user_data = file("user-data.sh")
+}
+
+module "ec2-public" {
+  source            = "../../modules/ec2"
+  instance_name     = "ec2-public"
+  vpc_id            = module.vpc.vpc_id
+  subnet_ids        = module.vpc.public_subnet_ids
+  ssh_allowed_ip    = ["0.0.0.0/0"]
+  ssh_allowed_ports = ["8443"]
+
+  assign_eip_address = true
 }

--- a/terraform/aws/examples/ec2/main.tf
+++ b/terraform/aws/examples/ec2/main.tf
@@ -1,0 +1,35 @@
+module "vpc" {
+  source                                  = "../../modules/vpc"
+  name_prefix                             = "qburst"
+  ipv4_primary_cidr_block                 = "10.16.0.0/16"
+  ipv4_additional_cidr_block_associations = ["10.20.0.0/16", "10.21.0.0/16"]
+  public_subnets_cidr                     = ["10.20.0.0/20", "10.20.16.0/20"]
+  private_subnets_cidr                    = ["10.21.0.0/20"]
+  availability_zones                      = ["ap-south-1a", "ap-south-1b"]
+}
+
+module "ec2" {
+  source            = "../../modules/ec2"
+  vpc_id            = module.vpc.vpc_id
+  subnet_ids        = module.vpc.private_subnet_ids
+  ssh_allowed_ip    = ["0.0.0.0/0"]
+  ssh_allowed_ports = [22]
+
+  instance_count = 3
+  ami            = "ami-099b3d23e336c2e83"
+  instance_type  = "t2.nano"
+
+  root_block_device = [
+    {
+      volume_type           = "gp2"
+      volume_size           = 15
+      delete_on_termination = true
+    }
+  ]
+
+  ebs_volume_enabled = true
+  ebs_volume_type    = "gp2"
+  ebs_volume_size    = 30
+
+  user_data = file("user-data.sh")
+}

--- a/terraform/aws/examples/ec2/provider.tf
+++ b/terraform/aws/examples/ec2/provider.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.0.0"
+}
+
+provider "aws" {
+  region = var.region
+  default_tags {
+    tags = {
+      Environment = "Test"
+      Project     = "QBurst"
+    }
+  }
+}
+
+variable "region" {
+  type        = string
+  description = "The default region to use"
+  default     = "ap-south-1"
+}

--- a/terraform/aws/examples/ec2/user-data.sh
+++ b/terraform/aws/examples/ec2/user-data.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+### Mountig ebs volume
+
+# Specify the target directory where you want to mount the devices
+mount_point="/data"
+
+# Device to skip
+device_to_skip="xvda"
+
+# Filesystem type
+filesystem_type="ext4"  # Change this to the appropriate filesystem type
+
+# Create the mount point directory if it doesn't exist
+sudo mkdir -p "$mount_point"
+
+# Use lsblk to list block devices, filter by type "disk" (whole disks)
+# and exclude read-only filesystems (ro)
+block_devices=$(lsblk -o NAME,TYPE,RO -r -n | awk '$2 == "disk" && $3 == "0" {print $1}')
+
+# Iterate through the block devices, skip the specified device, and attempt to mount the rest
+for device in $block_devices; do
+    if [ "$device" != "$device_to_skip" ]; then
+        echo "Mounting $device at $mount_point/$device"
+        sudo mkdir -p "$mount_point/$device"
+        sudo mkfs -t "$filesystem_type" "/dev/$device"  # Format the device with the specified filesystem
+        sudo mount "/dev/$device" "$mount_point/$device"
+        if [ $? -eq 0 ]; then
+            echo "Mounting successful."
+        else
+            echo "Failed to mount $device."
+        fi
+    else
+        echo "Skipping $device."
+    fi
+done
+echo "Mounting complete."

--- a/terraform/aws/modules/ec2/README.md
+++ b/terraform/aws/modules/ec2/README.md
@@ -1,0 +1,89 @@
+# AWS EC2 Module
+This module sets up an EC2 server in your account. It also can be used to launch a spot instance if you wish.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_allowed_ip"></a> [allowed\_ip](#input\_allowed\_ip) | List of allowed ip. | `list(any)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_allowed_ports"></a> [allowed\_ports](#input\_allowed\_ports) | List of allowed ingress ports | `list(any)` | <pre>[<br>  80,<br>  443<br>]</pre> | no |
+| <a name="input_ami"></a> [ami](#input\_ami) | The AMI to use for the instance. If not set the module will try to use the latest Ubuntu 22.04 image | `string` | `""` | no |
+| <a name="input_assign_eip_address"></a> [assign\_eip\_address](#input\_assign\_eip\_address) | Assign an Elastic IP address to the instance. | `bool` | `false` | no |
+| <a name="input_associate_public_ip_address"></a> [associate\_public\_ip\_address](#input\_associate\_public\_ip\_address) | Associate a public IP address with the instance. | `bool` | `false` | no |
+| <a name="input_availability_zone"></a> [availability\_zone](#input\_availability\_zone) | AZ to start the instance in | `string` | `null` | no |
+| <a name="input_cpu_core_count"></a> [cpu\_core\_count](#input\_cpu\_core\_count) | Sets the number of CPU cores for an instance. | `string` | `null` | no |
+| <a name="input_cpu_options"></a> [cpu\_options](#input\_cpu\_options) | Defines CPU options to apply to the instance at launch time. | `any` | `{}` | no |
+| <a name="input_cpu_threads_per_core"></a> [cpu\_threads\_per\_core](#input\_cpu\_threads\_per\_core) | Sets the number of CPU threads per core for an instance (has no effect unless cpu\_core\_count is also set) | `number` | `null` | no |
+| <a name="input_disable_api_termination"></a> [disable\_api\_termination](#input\_disable\_api\_termination) | If true, enables EC2 Instance Termination Protection. | `bool` | `false` | no |
+| <a name="input_dns_zone_id"></a> [dns\_zone\_id](#input\_dns\_zone\_id) | The Zone ID of Route53. If this is set, a DNS record is created for the instance. | `string` | `""` | no |
+| <a name="input_ebs_device_name"></a> [ebs\_device\_name](#input\_ebs\_device\_name) | Name of the EBS device to mount. | `list(string)` | <pre>[<br>  "/dev/xvdb",<br>  "/dev/xvdc"<br>]</pre> | no |
+| <a name="input_ebs_iops"></a> [ebs\_iops](#input\_ebs\_iops) | Amount of provisioned IOPS. This must be set with a volume\_type of io1. | `number` | `0` | no |
+| <a name="input_ebs_optimized"></a> [ebs\_optimized](#input\_ebs\_optimized) | If true, the launched EC2 instance will be EBS-optimized. | `bool` | `false` | no |
+| <a name="input_ebs_volume_enabled"></a> [ebs\_volume\_enabled](#input\_ebs\_volume\_enabled) | Flag to control the ebs creation. | `bool` | `false` | no |
+| <a name="input_ebs_volume_size"></a> [ebs\_volume\_size](#input\_ebs\_volume\_size) | Size of the EBS volume in gigabytes. | `number` | `30` | no |
+| <a name="input_ebs_volume_type"></a> [ebs\_volume\_type](#input\_ebs\_volume\_type) | The type of EBS volume. Can be standard, gp2 or io1. | `string` | `"gp2"` | no |
+| <a name="input_egress_ipv4_cidr_block"></a> [egress\_ipv4\_cidr\_block](#input\_egress\_ipv4\_cidr\_block) | List of CIDR blocks. Cannot be specified with source\_security\_group\_id or self. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_egress_ipv4_from_port"></a> [egress\_ipv4\_from\_port](#input\_egress\_ipv4\_from\_port) | Egress Start port (or ICMP type number if protocol is icmp or icmpv6). | `number` | `0` | no |
+| <a name="input_egress_ipv4_protocol"></a> [egress\_ipv4\_protocol](#input\_egress\_ipv4\_protocol) | Protocol. If not icmp, icmpv6, tcp, udp, or all use the protocol number | `string` | `"-1"` | no |
+| <a name="input_egress_ipv4_to_port"></a> [egress\_ipv4\_to\_port](#input\_egress\_ipv4\_to\_port) | Egress end port (or ICMP code if protocol is icmp). | `number` | `65535` | no |
+| <a name="input_egress_ipv6_cidr_block"></a> [egress\_ipv6\_cidr\_block](#input\_egress\_ipv6\_cidr\_block) | List of CIDR blocks. Cannot be specified with source\_security\_group\_id or self. | `list(string)` | <pre>[<br>  "::/0"<br>]</pre> | no |
+| <a name="input_egress_ipv6_from_port"></a> [egress\_ipv6\_from\_port](#input\_egress\_ipv6\_from\_port) | Egress Start port (or ICMP type number if protocol is icmp or icmpv6). | `number` | `0` | no |
+| <a name="input_egress_ipv6_protocol"></a> [egress\_ipv6\_protocol](#input\_egress\_ipv6\_protocol) | Protocol. If not icmp, icmpv6, tcp, udp, or all use the protocol number | `string` | `"-1"` | no |
+| <a name="input_egress_ipv6_to_port"></a> [egress\_ipv6\_to\_port](#input\_egress\_ipv6\_to\_port) | Egress end port (or ICMP code if protocol is icmp). | `number` | `65535` | no |
+| <a name="input_egress_rule"></a> [egress\_rule](#input\_egress\_rule) | Enable to create egress rule | `bool` | `true` | no |
+| <a name="input_enable_security_group"></a> [enable\_security\_group](#input\_enable\_security\_group) | Enable default Security Group with only Egress traffic allowed. | `bool` | `true` | no |
+| <a name="input_get_password_data"></a> [get\_password\_data](#input\_get\_password\_data) | If true, wait for password data to become available and retrieve it | `bool` | `null` | no |
+| <a name="input_host_id"></a> [host\_id](#input\_host\_id) | The Id of a dedicated host that the instance will be assigned to. Use when an instance is to be launched on a specific dedicated host. | `string` | `null` | no |
+| <a name="input_hostname"></a> [hostname](#input\_hostname) | DNS records to create. | `string` | `"ec2"` | no |
+| <a name="input_iam_instance_profile"></a> [iam\_instance\_profile](#input\_iam\_instance\_profile) | The IAM Instance Profile to launch the instance with. If not specified, the IAM profile is not set. | `string` | `""` | no |
+| <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Number of instances to launch. | `number` | `1` | no |
+| <a name="input_instance_name"></a> [instance\_name](#input\_instance\_name) | The base name of all instances being created | `string` | `"ec2-test"` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The type of instance to start. Updates to this field will trigger a stop/start of the EC2 instance. | `string` | `"t2.micro"` | no |
+| <a name="input_ipv6_address_count"></a> [ipv6\_address\_count](#input\_ipv6\_address\_count) | Number of IPv6 addresses to associate with the primary network interface. Amazon EC2 chooses the IPv6 addresses from the range of your subnet. | `number` | `null` | no |
+| <a name="input_ipv6_addresses"></a> [ipv6\_addresses](#input\_ipv6\_addresses) | List of IPv6 addresses from the range of the subnet to associate with the primary network interface. | `list(any)` | `null` | no |
+| <a name="input_is_external"></a> [is\_external](#input\_is\_external) | enable to udated existing security Group | `bool` | `false` | no |
+| <a name="input_kms_key"></a> [kms\_key](#input\_kms\_key) | This map has all the variables needed for using KMS | `map(any)` | <pre>{<br>  "alias": null,<br>  "deletion_window_in_days": 7,<br>  "description": "KMS master key",<br>  "enabled": true,<br>  "id": "",<br>  "multi_region": false<br>}</pre> | no |
+| <a name="input_monitoring"></a> [monitoring](#input\_monitoring) | If true, the launched EC2 instance will have detailed monitoring enabled. | `bool` | `false` | no |
+| <a name="input_multi_attach_enabled"></a> [multi\_attach\_enabled](#input\_multi\_attach\_enabled) | Specifies whether to enable Amazon EBS Multi-Attach. Multi-Attach is supported on io1 and io2 volumes. | `bool` | `false` | no |
+| <a name="input_private_ip"></a> [private\_ip](#input\_private\_ip) | Private IP address to associate with the instance in a VPC | `string` | `null` | no |
+| <a name="input_protocol"></a> [protocol](#input\_protocol) | The protocol. If not icmp, tcp, udp, or all use the. | `string` | `"tcp"` | no |
+| <a name="input_root_block_device"></a> [root\_block\_device](#input\_root\_block\_device) | Customize details about the root block device of the instance. See Block Devices below for details. | `list(any)` | `[]` | no |
+| <a name="input_secondary_private_ips"></a> [secondary\_private\_ips](#input\_secondary\_private\_ips) | A list of secondary private IPv4 addresses to assign to the instance's primary network interface (eth0) in a VPC. Can only be assigned to the primary network interface (eth0) attached at instance creation, not a pre-existing network interface i.e. referenced in a `network_interface block` | `list(string)` | `null` | no |
+| <a name="input_sg_description"></a> [sg\_description](#input\_sg\_description) | The security group description. | `string` | `"Instance default security group (only egress access is allowed)."` | no |
+| <a name="input_sg_egress_description"></a> [sg\_egress\_description](#input\_sg\_egress\_description) | Description of the egress and ingress rule | `string` | `"Description of the rule."` | no |
+| <a name="input_sg_egress_ipv6_description"></a> [sg\_egress\_ipv6\_description](#input\_sg\_egress\_ipv6\_description) | Description of the egress\_ipv6 rule | `string` | `"Description of the rule."` | no |
+| <a name="input_sg_ids"></a> [sg\_ids](#input\_sg\_ids) | List of the security group ids, in case they already exist | `list(any)` | `[]` | no |
+| <a name="input_sg_ingress_description"></a> [sg\_ingress\_description](#input\_sg\_ingress\_description) | Description of the ingress rule | `string` | `"Description of the ingress rule use elasticache."` | no |
+| <a name="input_source_dest_check"></a> [source\_dest\_check](#input\_source\_dest\_check) | Controls if traffic is routed to the instance when the destination address does not match the instance. Used for NAT or VPNs. | `bool` | `true` | no |
+| <a name="input_spot_block_duration_minutes"></a> [spot\_block\_duration\_minutes](#input\_spot\_block\_duration\_minutes) | The required duration for the Spot instances, in minutes. This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360) | `number` | `null` | no |
+| <a name="input_spot_instance_count"></a> [spot\_instance\_count](#input\_spot\_instance\_count) | Number of instances to launch. | `number` | `0` | no |
+| <a name="input_spot_instance_enabled"></a> [spot\_instance\_enabled](#input\_spot\_instance\_enabled) | Flag to control the instance creation. | `bool` | `true` | no |
+| <a name="input_spot_instance_interruption_behavior"></a> [spot\_instance\_interruption\_behavior](#input\_spot\_instance\_interruption\_behavior) | Indicates Spot instance behavior when it is interrupted. Valid values are `terminate`, `stop`, or `hibernate` | `string` | `null` | no |
+| <a name="input_spot_launch_group"></a> [spot\_launch\_group](#input\_spot\_launch\_group) | A launch group is a group of spot instances that launch together and terminate together. If left empty instances are launched and terminated individually | `string` | `null` | no |
+| <a name="input_spot_price"></a> [spot\_price](#input\_spot\_price) | The maximum price to request on the spot market. Defaults to on-demand price | `string` | `null` | no |
+| <a name="input_spot_type"></a> [spot\_type](#input\_spot\_type) | If set to one-time, after the instance is terminated, the spot request will be closed. Default `persistent` | `string` | `null` | no |
+| <a name="input_spot_valid_from"></a> [spot\_valid\_from](#input\_spot\_valid\_from) | The start date and time of the request, in UTC RFC3339 format(for example, YYYY-MM-DDTHH:MM:SSZ) | `string` | `null` | no |
+| <a name="input_spot_valid_until"></a> [spot\_valid\_until](#input\_spot\_valid\_until) | The end date and time of the request, in UTC RFC3339 format(for example, YYYY-MM-DDTHH:MM:SSZ) | `string` | `null` | no |
+| <a name="input_spot_wait_for_fulfillment"></a> [spot\_wait\_for\_fulfillment](#input\_spot\_wait\_for\_fulfillment) | If set, Terraform will wait for the Spot Request to be fulfilled, and will throw an error if the timeout of 10m is reached | `bool` | `false` | no |
+| <a name="input_ssh_allowed_ip"></a> [ssh\_allowed\_ip](#input\_ssh\_allowed\_ip) | List of allowed ip. | `list(any)` | `[]` | no |
+| <a name="input_ssh_allowed_ports"></a> [ssh\_allowed\_ports](#input\_ssh\_allowed\_ports) | List of allowed ingress ports | `list(any)` | `[]` | no |
+| <a name="input_ssh_key"></a> [ssh\_key](#input\_ssh\_key) | n/a | `map(any)` | <pre>{<br>  "algorithm": "RSA",<br>  "key_name": "",<br>  "public_key": "",<br>  "rsa_bits": 4096<br>}</pre> | no |
+| <a name="input_ssh_protocol"></a> [ssh\_protocol](#input\_ssh\_protocol) | The protocol. If not icmp, tcp, udp, or all use the. | `string` | `"tcp"` | no |
+| <a name="input_ssh_sg_ingress_description"></a> [ssh\_sg\_ingress\_description](#input\_ssh\_sg\_ingress\_description) | Description of the ingress rule | `string` | `"Description of the ingress rule use elasticache."` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of VPC Subnet IDs to launch in. | `list(string)` | `[]` | no |
+| <a name="input_tenancy"></a> [tenancy](#input\_tenancy) | The tenancy of the instance (if the instance is running in a VPC). An instance with a tenancy of 'dedicated' runs on single-tenant hardware. Valid values are 'default', 'dedicated', and 'host' | `string` | `"default"` | no |
+| <a name="input_ttl"></a> [ttl](#input\_ttl) | The TTL of the record to add to the DNS zone to complete certificate validation. | `string` | `"300"` | no |
+| <a name="input_type"></a> [type](#input\_type) | Type of DNS records to create. | `string` | `"CNAME"` | no |
+| <a name="input_user_data"></a> [user\_data](#input\_user\_data) | (Optional) A string of the desired User Data for the ec2. | `string` | `""` | no |
+| <a name="input_user_data_replace_on_change"></a> [user\_data\_replace\_on\_change](#input\_user\_data\_replace\_on\_change) | When used in combination with user\_data or user\_data\_base64 will trigger a destroy and recreate when set to true. Defaults to false if not set | `bool` | `null` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the VPC that the instance security group belongs to. | `string` | `""` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_instance_id"></a> [instance\_id](#output\_instance\_id) | The instance ID. |
+| <a name="output_private_ip"></a> [private\_ip](#output\_private\_ip) | Private IP of instance. |
+| <a name="output_public_ip"></a> [public\_ip](#output\_public\_ip) | Public IP of instance (or EIP). |
+| <a name="output_ssh_private_key"></a> [ssh\_private\_key](#output\_ssh\_private\_key) | n/a |
+| <a name="output_ssh_public_key"></a> [ssh\_public\_key](#output\_ssh\_public\_key) | n/a |

--- a/terraform/aws/modules/ec2/ec2.tf
+++ b/terraform/aws/modules/ec2/ec2.tf
@@ -1,0 +1,106 @@
+data "aws_ami" "ubuntu" {
+  most_recent = "true"
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-*"]
+  }
+}
+
+data "aws_caller_identity" "this" {}
+
+resource "aws_instance" "default" {
+  count                       = var.instance_count
+  ami                         = var.ami == "" ? data.aws_ami.ubuntu.id : var.ami
+  ebs_optimized               = var.ebs_optimized
+  instance_type               = var.instance_type
+  key_name                    = var.ssh_key.key_name == "" ? join("", aws_key_pair.default[*].key_name) : var.ssh_key.key_name
+  monitoring                  = var.monitoring
+  vpc_security_group_ids      = length(var.sg_ids) < 1 ? aws_security_group.default[*].id : var.sg_ids
+  subnet_id                   = element(distinct(compact(concat(var.subnet_ids))), count.index)
+  associate_public_ip_address = var.associate_public_ip_address
+  disable_api_termination     = var.disable_api_termination
+  tenancy                     = var.tenancy
+  host_id                     = var.host_id
+  cpu_core_count              = var.cpu_core_count
+  cpu_threads_per_core        = var.cpu_threads_per_core
+  user_data                   = var.user_data
+  user_data_replace_on_change = var.user_data_replace_on_change
+  availability_zone           = var.availability_zone
+  get_password_data           = var.get_password_data
+  private_ip                  = var.private_ip
+  secondary_private_ips       = var.secondary_private_ips
+  iam_instance_profile        = join("", aws_iam_instance_profile.default[*].name)
+  source_dest_check           = var.source_dest_check
+  ipv6_address_count          = var.ipv6_address_count
+  ipv6_addresses              = var.ipv6_addresses
+
+  dynamic "cpu_options" {
+    for_each = length(var.cpu_options) > 0 ? [var.cpu_options] : []
+    content {
+      core_count       = lookup(cpu_options, "core_count", null)
+      threads_per_core = lookup(cpu_options, "threads_per_core", null)
+      amd_sev_snp      = lookup(cpu_options, "amd_sev_snp", null)
+    }
+  }
+
+  dynamic "root_block_device" {
+    for_each = var.root_block_device
+    content {
+      delete_on_termination = lookup(root_block_device.value, "delete_on_termination", null)
+      encrypted             = true
+      iops                  = lookup(root_block_device.value, "iops", null)
+      kms_key_id            = var.kms_key.id == "" ? join("", aws_ssh_key.default[*].arn) : lookup(root_block_device.value, "kms_key.id", null)
+      volume_size           = lookup(root_block_device.value, "volume_size", null)
+      volume_type           = lookup(root_block_device.value, "volume_type", null)
+      tags = {
+        Name = "${var.instance_name}-${count.index}-root-volume"
+      }
+    }
+  }
+
+  tags = {
+    Name = "${var.instance_name}-${count.index}"
+  }
+  lifecycle {
+    ignore_changes = [
+      private_ip,
+    ]
+  }
+}
+
+resource "aws_eip" "default" {
+  count             = var.assign_eip_address ? var.instance_count : 0
+  network_interface = element(aws_instance.default[*].primary_network_interface_id, count.index)
+  tags = {
+    Name = "${var.instance_name}-${count.index}-eip"
+  }
+}
+
+resource "aws_ebs_volume" "default" {
+  count                = var.ebs_volume_enabled ? var.instance_count : 0
+  availability_zone    = element(aws_instance.default[*].availability_zone, count.index)
+  size                 = var.ebs_volume_size
+  iops                 = (var.ebs_volume_type == "io1" || var.ebs_volume_type == "io2" || var.ebs_volume_type == "gp3") ? var.ebs_iops : 0
+  type                 = var.ebs_volume_type
+  multi_attach_enabled = (var.ebs_volume_type == "io1" || var.ebs_volume_type == "io2") ? var.multi_attach_enabled : false
+  encrypted            = true
+  kms_key_id           = var.kms_key.id == "" ? join("", aws_kms_key.default[*].arn) : var.kms_key.id
+  tags = {
+    Name = "${var.instance_name}-${count.index}-ebs-volume"
+  }
+  depends_on = [aws_instance.default]
+}
+
+resource "aws_volume_attachment" "default" {
+  count       = var.ebs_volume_enabled ? var.instance_count : 0
+  device_name = element(var.ebs_device_name, count.index)
+  volume_id   = element(aws_ebs_volume.default[*].id, count.index)
+  instance_id = element(aws_instance.default[*].id, count.index)
+  depends_on  = [aws_instance.default]
+}
+
+resource "aws_iam_instance_profile" "default" {
+  count = length(var.iam_instance_profile) > 0 ? 1 : 0
+  name  = var.iam_instance_profile
+  role  = var.iam_instance_profile
+}

--- a/terraform/aws/modules/ec2/ec2.tf
+++ b/terraform/aws/modules/ec2/ec2.tf
@@ -49,7 +49,7 @@ resource "aws_instance" "default" {
       delete_on_termination = lookup(root_block_device.value, "delete_on_termination", null)
       encrypted             = true
       iops                  = lookup(root_block_device.value, "iops", null)
-      kms_key_id            = var.kms_key.id == "" ? join("", aws_ssh_key.default[*].arn) : lookup(root_block_device.value, "kms_key.id", null)
+      kms_key_id            = var.kms_key.id == "" ? join("", aws_kms_key.default[*].arn) : lookup(root_block_device.value, "kms_key.id", null)
       volume_size           = lookup(root_block_device.value, "volume_size", null)
       volume_type           = lookup(root_block_device.value, "volume_type", null)
       tags = {

--- a/terraform/aws/modules/ec2/ec2.tf
+++ b/terraform/aws/modules/ec2/ec2.tf
@@ -4,6 +4,7 @@ data "aws_ami" "ubuntu" {
     name   = "name"
     values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-*"]
   }
+  owners = ["099720109477"]
 }
 
 data "aws_caller_identity" "this" {}
@@ -63,7 +64,7 @@ resource "aws_instance" "default" {
   }
   lifecycle {
     ignore_changes = [
-      private_ip,
+      private_ip, associate_public_ip_address
     ]
   }
 }

--- a/terraform/aws/modules/ec2/key-pair.tf
+++ b/terraform/aws/modules/ec2/key-pair.tf
@@ -1,0 +1,14 @@
+resource "tls_private_key" "default" {
+  count     = var.ssh_key.public_key == "" && var.ssh_key.key_name == "" ? 1 : 0
+  algorithm = var.ssh_key.algorithm
+  rsa_bits  = var.ssh_key.rsa_bits
+}
+
+resource "aws_key_pair" "default" {
+  count      = var.ssh_key.key_name == "" ? 1 : 0
+  key_name   = var.instance_name
+  public_key = var.ssh_key.public_key == "" ? join("", tls_private_key.default[*].public_key_openssh) : var.ssh_key.public_key
+  tags = {
+    Name = "${var.instance_name}-key"
+  }
+}

--- a/terraform/aws/modules/ec2/kms.tf
+++ b/terraform/aws/modules/ec2/kms.tf
@@ -1,0 +1,32 @@
+resource "aws_kms_key" "default" {
+  count                   = var.kms_key.enabled && var.kms_key.id == "" ? 1 : 0
+  description             = var.kms_key.description
+  deletion_window_in_days = var.kms_key.deletion_window_in_days
+  is_enabled              = var.kms_key.enabled
+  enable_key_rotation     = true
+  policy                  = data.aws_iam_policy_document.kms.json
+  multi_region            = var.kms_key.multi_region
+  tags = {
+    Name = "${var.instance_name}-kms-key"
+  }
+}
+
+resource "aws_kms_alias" "default" {
+  count         = var.kms_key.enabled && var.kms_key.id == "" ? 1 : 0
+  name          = coalesce(var.kms_key.alias, "alias/${var.instance_name}")
+  target_key_id = var.kms_key.id == "" ? join("", aws_kms_key.default[*].id) : var.kms_key.id
+}
+
+data "aws_iam_policy_document" "kms" {
+  version = "2012-10-17"
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = [format("arn:aws:iam::%s:root", data.aws_caller_identity.this.account_id)]
+    }
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+}

--- a/terraform/aws/modules/ec2/outputs.tf
+++ b/terraform/aws/modules/ec2/outputs.tf
@@ -1,0 +1,15 @@
+output "instance_id" {
+  value       = aws_instance.default[*].id
+  description = "The instance ID."
+}
+
+output "public_ip" {
+  value       = concat(aws_eip.default[*].public_ip, aws_instance.default[*].public_ip, [""])
+  description = "Public IP of instance (or EIP)."
+
+}
+
+output "private_ip" {
+  value       = aws_instance.default[*].private_ip
+  description = "Private IP of instance."
+}

--- a/terraform/aws/modules/ec2/outputs.tf
+++ b/terraform/aws/modules/ec2/outputs.tf
@@ -13,3 +13,13 @@ output "private_ip" {
   value       = aws_instance.default[*].private_ip
   description = "Private IP of instance."
 }
+
+output "ssh_private_key" {
+  value     = tls_private_key.default[*].private_key_pem
+  sensitive = true
+}
+
+output "ssh_public_key" {
+  value     = tls_private_key.default[*].public_key_openssh
+  sensitive = true
+}

--- a/terraform/aws/modules/ec2/route53.tf
+++ b/terraform/aws/modules/ec2/route53.tf
@@ -1,0 +1,8 @@
+resource "aws_route53_record" "default" {
+  count   = length(var.dns_zone_id) > 0 ? var.instance_count : 0
+  zone_id = var.dns_zone_id
+  name    = "${var.hostname}-${count.index}"
+  type    = var.type
+  ttl     = var.ttl
+  records = [element(aws_instance.default[*].private_dns, count.index)]
+}

--- a/terraform/aws/modules/ec2/security_group.tf
+++ b/terraform/aws/modules/ec2/security_group.tf
@@ -1,0 +1,57 @@
+resource "aws_security_group" "default" {
+  count       = var.enable_security_group && length(var.sg_ids) < 1 ? 1 : 0
+  name        = "${var.instance_name}-sg"
+  vpc_id      = var.vpc_id
+  description = var.sg_description
+  lifecycle {
+    create_before_destroy = true
+  }
+  tags = {
+    Name = "${var.instance_name}-sg"
+  }
+}
+
+resource "aws_security_group_rule" "egress_ipv4" {
+  count             = (var.enable_security_group && length(var.sg_ids) < 1 && var.is_external == false && var.egress_rule) ? 1 : 0
+  description       = var.sg_egress_description
+  type              = "egress"
+  from_port         = var.egress_ipv4_from_port
+  to_port           = var.egress_ipv4_to_port
+  protocol          = var.egress_ipv4_protocol
+  cidr_blocks       = var.egress_ipv4_cidr_block
+  security_group_id = join("", aws_security_group.default[*].id)
+}
+
+resource "aws_security_group_rule" "egress_ipv6" {
+  count             = var.enable_security_group && length(var.sg_ids) < 1 && var.is_external == false && var.egress_rule ? 1 : 0
+  description       = var.sg_egress_ipv6_description
+  type              = "egress"
+  from_port         = var.egress_ipv6_from_port
+  to_port           = var.egress_ipv6_to_port
+  protocol          = var.egress_ipv6_protocol
+  ipv6_cidr_blocks  = var.egress_ipv6_cidr_block
+  security_group_id = join("", aws_security_group.default[*].id)
+}
+
+resource "aws_security_group_rule" "ssh_ingress" {
+  count             = length(var.ssh_allowed_ip) > 0 && length(var.sg_ids) < 1 ? length(compact(var.ssh_allowed_ports)) : 0
+  description       = var.ssh_sg_ingress_description
+  type              = "ingress"
+  from_port         = element(var.ssh_allowed_ports, count.index)
+  to_port           = element(var.ssh_allowed_ports, count.index)
+  protocol          = var.ssh_protocol
+  cidr_blocks       = var.ssh_allowed_ip
+  security_group_id = join("", aws_security_group.default[*].id)
+}
+
+resource "aws_security_group_rule" "ingress" {
+  count = length(var.allowed_ip) > 0 && length(var.sg_ids) < 1 ? length(compact(var.allowed_ports)) : 0
+
+  description       = var.sg_ingress_description
+  type              = "ingress"
+  from_port         = element(var.allowed_ports, count.index)
+  to_port           = element(var.allowed_ports, count.index)
+  protocol          = var.protocol
+  cidr_blocks       = var.allowed_ip
+  security_group_id = join("", aws_security_group.default[*].id)
+}

--- a/terraform/aws/modules/ec2/spot.tf
+++ b/terraform/aws/modules/ec2/spot.tf
@@ -61,7 +61,7 @@ resource "aws_spot_instance_request" "default" {
   }
   lifecycle {
     ignore_changes = [
-      private_ip,
+      private_ip, associate_public_ip_address
     ]
   }
 }

--- a/terraform/aws/modules/ec2/spot.tf
+++ b/terraform/aws/modules/ec2/spot.tf
@@ -47,7 +47,7 @@ resource "aws_spot_instance_request" "default" {
       delete_on_termination = lookup(root_block_device.value, "delete_on_termination", null)
       encrypted             = true
       iops                  = lookup(root_block_device.value, "iops", null)
-      kms_key_id            = var.ssh_key_id == "" ? join("", aws_ssh_key.default[*].arn) : lookup(root_block_device.value, "ssh_key_id", null)
+      kms_key_id            = var.kms_key_id == "" ? join("", aws_kms_key.default[*].arn) : lookup(root_block_device.value, "kms_key_id", null)
       volume_size           = lookup(root_block_device.value, "volume_size", null)
       volume_type           = lookup(root_block_device.value, "volume_type", null)
       tags = {

--- a/terraform/aws/modules/ec2/spot.tf
+++ b/terraform/aws/modules/ec2/spot.tf
@@ -1,0 +1,67 @@
+resource "aws_spot_instance_request" "default" {
+  count                          = var.spot_instance_enabled ? var.spot_instance_count : 0
+  spot_price                     = var.spot_price
+  wait_for_fulfillment           = var.spot_wait_for_fulfillment
+  spot_type                      = var.spot_type
+  launch_group                   = var.spot_launch_group
+  block_duration_minutes         = var.spot_block_duration_minutes
+  instance_interruption_behavior = var.spot_instance_interruption_behavior
+  valid_until                    = var.spot_valid_until
+  valid_from                     = var.spot_valid_from
+  ami                            = var.ami == "" ? data.aws_ami.ubuntu.id : var.ami
+  ebs_optimized                  = var.ebs_optimized
+  instance_type                  = var.instance_type
+  key_name                       = var.ssh_key.key_name == "" ? join("", aws_key_pair.default[*].key_name) : var.ssh_key.key_name
+  monitoring                     = var.monitoring
+  vpc_security_group_ids         = length(var.sg_ids) < 1 ? aws_security_group.default[*].id : var.sg_ids
+  subnet_id                      = element(distinct(compact(concat(var.subnet_ids))), count.index)
+  associate_public_ip_address    = var.associate_public_ip_address
+  disable_api_termination        = var.disable_api_termination
+  tenancy                        = var.tenancy
+  host_id                        = var.host_id
+  cpu_core_count                 = var.cpu_core_count
+  cpu_threads_per_core           = var.cpu_threads_per_core
+  user_data                      = var.user_data
+  user_data_replace_on_change    = var.user_data_replace_on_change
+  availability_zone              = var.availability_zone
+  get_password_data              = var.get_password_data
+  private_ip                     = var.private_ip
+  secondary_private_ips          = var.secondary_private_ips
+  iam_instance_profile           = join("", aws_iam_instance_profile.default[*].name)
+  source_dest_check              = var.source_dest_check
+  ipv6_address_count             = var.ipv6_address_count
+  ipv6_addresses                 = var.ipv6_addresses
+
+  dynamic "cpu_options" {
+    for_each = length(var.cpu_options) > 0 ? [var.cpu_options] : []
+    content {
+      core_count       = lookup(cpu_options, "core_count", null)
+      threads_per_core = lookup(cpu_options, "threads_per_core", null)
+      amd_sev_snp      = lookup(cpu_options, "amd_sev_snp", null)
+    }
+  }
+
+  dynamic "root_block_device" {
+    for_each = var.root_block_device
+    content {
+      delete_on_termination = lookup(root_block_device.value, "delete_on_termination", null)
+      encrypted             = true
+      iops                  = lookup(root_block_device.value, "iops", null)
+      kms_key_id            = var.ssh_key_id == "" ? join("", aws_ssh_key.default[*].arn) : lookup(root_block_device.value, "ssh_key_id", null)
+      volume_size           = lookup(root_block_device.value, "volume_size", null)
+      volume_type           = lookup(root_block_device.value, "volume_type", null)
+      tags = {
+        Name = "${var.instance_name}-${count.index}-root-volume"
+      }
+    }
+  }
+
+  tags = {
+    Name = "${var.instance_name}-${count.index}-root-volume"
+  }
+  lifecycle {
+    ignore_changes = [
+      private_ip,
+    ]
+  }
+}

--- a/terraform/aws/modules/ec2/variables.tf
+++ b/terraform/aws/modules/ec2/variables.tf
@@ -1,0 +1,447 @@
+variable "instance_name" {
+  type        = string
+  default     = "ec2-test"
+  description = "The base name of all instances being created"
+}
+
+variable "instance_count" {
+  type        = number
+  default     = 1
+  description = "Number of instances to launch."
+}
+
+variable "ami" {
+  type        = string
+  default     = ""
+  description = "The AMI to use for the instance. If not set the module will try to use the latest Ubuntu 22.04 image"
+}
+
+variable "ebs_optimized" {
+  type        = bool
+  default     = false
+  description = "If true, the launched EC2 instance will be EBS-optimized."
+}
+
+variable "instance_type" {
+  type        = string
+  default     = "t2-micro"
+  description = "The type of instance to start. Updates to this field will trigger a stop/start of the EC2 instance."
+}
+
+variable "monitoring" {
+  type        = bool
+  default     = false
+  description = "If true, the launched EC2 instance will have detailed monitoring enabled."
+}
+
+variable "associate_public_ip_address" {
+  type        = bool
+  default     = false
+  description = "Associate a public IP address with the instance."
+}
+
+variable "disable_api_termination" {
+  type        = bool
+  default     = false
+  description = "If true, enables EC2 Instance Termination Protection."
+}
+
+variable "tenancy" {
+  type        = string
+  default     = "default"
+  description = "The tenancy of the instance (if the instance is running in a VPC). An instance with a tenancy of 'dedicated' runs on single-tenant hardware. Valid values are 'default', 'dedicated', and 'host'"
+}
+
+variable "root_block_device" {
+  type        = list(any)
+  default     = []
+  description = "Customize details about the root block device of the instance. See Block Devices below for details."
+}
+
+variable "user_data" {
+  type        = string
+  default     = ""
+  description = "(Optional) A string of the desired User Data for the ec2."
+}
+
+variable "assign_eip_address" {
+  type        = bool
+  default     = true
+  description = "Assign an Elastic IP address to the instance."
+  sensitive   = true
+}
+
+variable "ebs_iops" {
+  type        = number
+  default     = 0
+  description = "Amount of provisioned IOPS. This must be set with a volume_type of io1."
+}
+
+variable "ebs_device_name" {
+  type        = list(string)
+  default     = ["/dev/xvdb", "/dev/xvdc"]
+  description = "Name of the EBS device to mount."
+}
+
+variable "ebs_volume_size" {
+  type        = number
+  default     = 30
+  description = "Size of the EBS volume in gigabytes."
+}
+
+variable "ebs_volume_type" {
+  type        = string
+  default     = "gp2"
+  description = "The type of EBS volume. Can be standard, gp2 or io1."
+}
+
+variable "ebs_volume_enabled" {
+  type        = bool
+  default     = false
+  description = "Flag to control the ebs creation."
+}
+
+variable "iam_instance_profile" {
+  type        = string
+  default     = ""
+  description = "The IAM Instance Profile to launch the instance with. If not specified, the IAM profile is not set."
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  default     = []
+  description = "A list of VPC Subnet IDs to launch in."
+}
+
+variable "source_dest_check" {
+  type        = bool
+  default     = true
+  description = "Controls if traffic is routed to the instance when the destination address does not match the instance. Used for NAT or VPNs."
+}
+
+variable "ipv6_address_count" {
+  type        = number
+  default     = null
+  description = "Number of IPv6 addresses to associate with the primary network interface. Amazon EC2 chooses the IPv6 addresses from the range of your subnet."
+}
+
+variable "ipv6_addresses" {
+  type        = list(any)
+  default     = null
+  description = "List of IPv6 addresses from the range of the subnet to associate with the primary network interface."
+  sensitive   = true
+}
+
+variable "host_id" {
+  type        = string
+  default     = null
+  description = "The Id of a dedicated host that the instance will be assigned to. Use when an instance is to be launched on a specific dedicated host."
+}
+
+variable "cpu_core_count" {
+  type        = string
+  default     = null
+  description = "Sets the number of CPU cores for an instance."
+}
+
+variable "dns_zone_id" {
+  type        = string
+  default     = ""
+  description = "The Zone ID of Route53. If this is set, a DNS record is created for the instance."
+  sensitive   = true
+}
+
+variable "hostname" {
+  type        = string
+  default     = "ec2"
+  description = "DNS records to create."
+}
+
+variable "type" {
+  type        = string
+  default     = "CNAME"
+  description = "Type of DNS records to create."
+}
+
+variable "ttl" {
+  type        = string
+  default     = "300"
+  description = "The TTL of the record to add to the DNS zone to complete certificate validation."
+}
+
+variable "multi_attach_enabled" {
+  type        = bool
+  default     = false
+  description = "Specifies whether to enable Amazon EBS Multi-Attach. Multi-Attach is supported on io1 and io2 volumes."
+}
+
+variable "kms_key" {
+  type        = map(any)
+  description = "This map has all the variables needed for using KMS"
+  default = {
+    enabled                 = true
+    description             = "KMS master key" # The description of the key
+    id                      = ""               # The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption.
+    alias                   = "alias/ec2-test" # The display name of the alias.
+    deletion_window_in_days = 7
+    multi_region            = false # Indicates whether the key is a multi-Region (true) or regional (false) key
+  }
+}
+
+variable "vpc_id" {
+  type        = string
+  default     = ""
+  description = "The ID of the VPC that the instance security group belongs to."
+  sensitive   = true
+}
+
+variable "allowed_ip" {
+  type        = list(any)
+  default     = ["0.0.0.0/0"]
+  description = "List of allowed ip."
+}
+
+variable "allowed_ports" {
+  type        = list(any)
+  default     = [80, 443]
+  description = "List of allowed ingress ports"
+}
+
+variable "protocol" {
+  type        = string
+  default     = "tcp"
+  description = "The protocol. If not icmp, tcp, udp, or all use the."
+}
+
+variable "enable_security_group" {
+  type        = bool
+  default     = true
+  description = "Enable default Security Group with only Egress traffic allowed."
+}
+
+variable "egress_rule" {
+  type        = bool
+  default     = true
+  description = "Enable to create egress rule"
+}
+
+variable "is_external" {
+  type        = bool
+  default     = false
+  description = "enable to udated existing security Group"
+}
+
+variable "sg_ids" {
+  type        = list(any)
+  default     = []
+  description = "List of the security group ids, in case they already exist"
+}
+
+variable "sg_description" {
+  type        = string
+  default     = "Instance default security group (only egress access is allowed)."
+  description = "The security group description."
+}
+
+variable "sg_egress_description" {
+  type        = string
+  default     = "Description of the rule."
+  description = "Description of the egress and ingress rule"
+}
+
+variable "sg_egress_ipv6_description" {
+  type        = string
+  default     = "Description of the rule."
+  description = "Description of the egress_ipv6 rule"
+}
+
+variable "sg_ingress_description" {
+  type        = string
+  default     = "Description of the ingress rule use elasticache."
+  description = "Description of the ingress rule"
+}
+
+variable "ssh_allowed_ip" {
+  type        = list(any)
+  default     = []
+  description = "List of allowed ip."
+}
+
+variable "ssh_allowed_ports" {
+  type        = list(any)
+  default     = []
+  description = "List of allowed ingress ports"
+}
+
+variable "ssh_protocol" {
+  type        = string
+  default     = "tcp"
+  description = "The protocol. If not icmp, tcp, udp, or all use the."
+}
+
+variable "ssh_sg_ingress_description" {
+  type        = string
+  default     = "Description of the ingress rule use elasticache."
+  description = "Description of the ingress rule"
+}
+
+variable "ssh_key" {
+  type = map(any)
+  default = {
+    key_name   = "" # Key name of the Key Pair to use for the instance; if not specified it will create a new key pair.
+    public_key = "" # the public key of the key pair (e.g. `ssh-rsa AABBCCDDEE44554422`).
+    algorithm  = "RSA"
+    rsa_bits   = 4096
+  }
+}
+
+###### spot
+variable "spot_instance_enabled" {
+  type        = bool
+  default     = true
+  description = "Flag to control the instance creation."
+}
+
+variable "spot_instance_count" {
+  type        = number
+  default     = 0
+  description = "Number of instances to launch."
+}
+
+variable "spot_price" {
+  type        = string
+  default     = null
+  description = "The maximum price to request on the spot market. Defaults to on-demand price"
+}
+
+variable "spot_wait_for_fulfillment" {
+  type        = bool
+  default     = false
+  description = "If set, Terraform will wait for the Spot Request to be fulfilled, and will throw an error if the timeout of 10m is reached"
+}
+
+variable "spot_type" {
+  type        = string
+  default     = null
+  description = "If set to one-time, after the instance is terminated, the spot request will be closed. Default `persistent`"
+}
+
+variable "spot_launch_group" {
+  type        = string
+  default     = null
+  description = "A launch group is a group of spot instances that launch together and terminate together. If left empty instances are launched and terminated individually"
+}
+
+variable "spot_block_duration_minutes" {
+  type        = number
+  default     = null
+  description = "The required duration for the Spot instances, in minutes. This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360)"
+}
+
+variable "spot_instance_interruption_behavior" {
+  type        = string
+  default     = null
+  description = "Indicates Spot instance behavior when it is interrupted. Valid values are `terminate`, `stop`, or `hibernate`"
+}
+
+variable "spot_valid_until" {
+  type        = string
+  default     = null
+  description = "The end date and time of the request, in UTC RFC3339 format(for example, YYYY-MM-DDTHH:MM:SSZ)"
+}
+
+variable "spot_valid_from" {
+  type        = string
+  default     = null
+  description = "The start date and time of the request, in UTC RFC3339 format(for example, YYYY-MM-DDTHH:MM:SSZ)"
+}
+
+variable "cpu_threads_per_core" {
+  description = "Sets the number of CPU threads per core for an instance (has no effect unless cpu_core_count is also set)"
+  type        = number
+  default     = null
+}
+
+variable "user_data_replace_on_change" {
+  description = "When used in combination with user_data or user_data_base64 will trigger a destroy and recreate when set to true. Defaults to false if not set"
+  type        = bool
+  default     = null
+}
+
+variable "availability_zone" {
+  description = "AZ to start the instance in"
+  type        = string
+  default     = null
+}
+
+variable "get_password_data" {
+  description = "If true, wait for password data to become available and retrieve it"
+  type        = bool
+  default     = null
+}
+
+variable "private_ip" {
+  description = "Private IP address to associate with the instance in a VPC"
+  type        = string
+  default     = null
+}
+
+variable "secondary_private_ips" {
+  description = "A list of secondary private IPv4 addresses to assign to the instance's primary network interface (eth0) in a VPC. Can only be assigned to the primary network interface (eth0) attached at instance creation, not a pre-existing network interface i.e. referenced in a `network_interface block`"
+  type        = list(string)
+  default     = null
+}
+
+variable "egress_ipv4_from_port" {
+  description = "Egress Start port (or ICMP type number if protocol is icmp or icmpv6)."
+  type        = number
+  default     = 0
+}
+
+variable "egress_ipv4_to_port" {
+  description = "Egress end port (or ICMP code if protocol is icmp)."
+  type        = number
+  default     = 65535
+}
+
+variable "egress_ipv4_protocol" {
+  description = "Protocol. If not icmp, icmpv6, tcp, udp, or all use the protocol number"
+  type        = string
+  default     = "-1"
+}
+
+variable "egress_ipv4_cidr_block" {
+  description = " List of CIDR blocks. Cannot be specified with source_security_group_id or self."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "egress_ipv6_from_port" {
+  description = "Egress Start port (or ICMP type number if protocol is icmp or icmpv6)."
+  type        = number
+  default     = 0
+}
+
+variable "egress_ipv6_to_port" {
+  description = "Egress end port (or ICMP code if protocol is icmp)."
+  type        = number
+  default     = 65535
+}
+
+variable "egress_ipv6_protocol" {
+  description = "Protocol. If not icmp, icmpv6, tcp, udp, or all use the protocol number"
+  type        = string
+  default     = "-1"
+}
+
+variable "egress_ipv6_cidr_block" {
+  description = " List of CIDR blocks. Cannot be specified with source_security_group_id or self."
+  type        = list(string)
+  default     = ["::/0"]
+}
+
+variable "cpu_options" {
+  description = "Defines CPU options to apply to the instance at launch time."
+  type        = any
+  default     = {}
+}

--- a/terraform/aws/modules/ec2/variables.tf
+++ b/terraform/aws/modules/ec2/variables.tf
@@ -24,7 +24,7 @@ variable "ebs_optimized" {
 
 variable "instance_type" {
   type        = string
-  default     = "t2-micro"
+  default     = "t2.micro"
   description = "The type of instance to start. Updates to this field will trigger a stop/start of the EC2 instance."
 }
 
@@ -66,7 +66,7 @@ variable "user_data" {
 
 variable "assign_eip_address" {
   type        = bool
-  default     = true
+  default     = false
   description = "Assign an Elastic IP address to the instance."
   sensitive   = true
 }
@@ -182,7 +182,7 @@ variable "kms_key" {
     enabled                 = true
     description             = "KMS master key" # The description of the key
     id                      = ""               # The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption.
-    alias                   = "alias/ec2-test" # The display name of the alias.
+    alias                   = null
     deletion_window_in_days = 7
     multi_region            = false # Indicates whether the key is a multi-Region (true) or regional (false) key
   }

--- a/terraform/aws/modules/vpc/vpc.tf
+++ b/terraform/aws/modules/vpc/vpc.tf
@@ -46,8 +46,8 @@ resource "aws_subnet" "public" {
 
 # Elastic IP
 resource "aws_eip" "nat_gw" {
-  count = length(var.public_subnets_cidr) > 0 && var.nat_gw_enabled ? 1 : 0
-  vpc   = true
+  count  = length(var.public_subnets_cidr) > 0 && var.nat_gw_enabled ? 1 : 0
+  domain = "vpc"
 
   tags = {
     Name = "${var.name_prefix}-nat-eip"


### PR DESCRIPTION
Pls find the plan for the same (Removing the VPC section of the plan)

```
Terraform will perform the following actions:

  # module.ec2-private.aws_ebs_volume.default[0] will be created
  + resource "aws_ebs_volume" "default" {
      + arn                  = (known after apply)
      + availability_zone    = (known after apply)
      + encrypted            = true
      + final_snapshot       = false
      + id                   = (known after apply)
      + iops                 = 0
      + kms_key_id           = (known after apply)
      + multi_attach_enabled = false
      + size                 = 30
      + snapshot_id          = (known after apply)
      + tags                 = {
          + "Name" = "ec2-private-0-ebs-volume"
        }
      + tags_all             = {
          + "Environment" = "Test"
          + "Name"        = "ec2-private-0-ebs-volume"
          + "Project"     = "QBurst"
        }
      + throughput           = (known after apply)
      + type                 = "gp2"
    }

  # module.ec2-private.aws_instance.default[0] will be created
  + resource "aws_instance" "default" {
      + ami                                  = "ami-099b3d23e336c2e83"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = false
      + availability_zone                    = (known after apply)
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + disable_api_stop                     = (known after apply)
      + disable_api_termination              = false
      + ebs_optimized                        = false
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + host_resource_group_arn              = (known after apply)
      + iam_instance_profile                 = (known after apply)
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_lifecycle                   = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "t2.nano"
      + ipv6_address_count                   = (known after apply)
      + ipv6_addresses                       = (sensitive value)
      + key_name                             = "ec2-private"
      + monitoring                           = false
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + placement_partition_number           = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + secondary_private_ips                = (known after apply)
      + security_groups                      = (known after apply)
      + source_dest_check                    = true
      + spot_instance_request_id             = (known after apply)
      + subnet_id                            = (known after apply)
      + tags                                 = {
          + "Name" = "ec2-private-0"
        }
      + tags_all                             = {
          + "Environment" = "Test"
          + "Name"        = "ec2-private-0"
          + "Project"     = "QBurst"
        }
      + tenancy                              = "default"
      + user_data                            = "b0f3be9595a47178000e5e62edea7bffbc262f39"
      + user_data_base64                     = (known after apply)
      + user_data_replace_on_change          = false
      + vpc_security_group_ids               = (known after apply)

      + root_block_device {
          + delete_on_termination = true
          + device_name           = (known after apply)
          + encrypted             = true
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + tags                  = {
              + "Name" = "ec2-private-0-root-volume"
            }
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = 15
          + volume_type           = "gp2"
        }
    }

  # module.ec2-private.aws_key_pair.default[0] will be created
  + resource "aws_key_pair" "default" {
      + arn             = (known after apply)
      + fingerprint     = (known after apply)
      + id              = (known after apply)
      + key_name        = "ec2-private"
      + key_name_prefix = (known after apply)
      + key_pair_id     = (known after apply)
      + key_type        = (known after apply)
      + public_key      = (known after apply)
      + tags            = {
          + "Name" = "ec2-private-key"
        }
      + tags_all        = {
          + "Environment" = "Test"
          + "Name"        = "ec2-private-key"
          + "Project"     = "QBurst"
        }
    }

  # module.ec2-private.aws_kms_alias.default[0] will be created
  + resource "aws_kms_alias" "default" {
      + arn            = (known after apply)
      + id             = (known after apply)
      + name           = "alias/ec2-private"
      + name_prefix    = (known after apply)
      + target_key_arn = (known after apply)
      + target_key_id  = (known after apply)
    }

  # module.ec2-private.aws_kms_key.default[0] will be created
  + resource "aws_kms_key" "default" {
      + arn                                = (known after apply)
      + bypass_policy_lockout_safety_check = false
      + customer_master_key_spec           = "SYMMETRIC_DEFAULT"
      + deletion_window_in_days            = 7
      + description                        = "KMS master key"
      + enable_key_rotation                = true
      + id                                 = (known after apply)
      + is_enabled                         = true
      + key_id                             = (known after apply)
      + key_usage                          = "ENCRYPT_DECRYPT"
      + multi_region                       = false
      + policy                             = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "kms:*"
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::062427305583:root"
                        }
                      + Resource  = "*"
                      + Sid       = "Enable IAM User Permissions"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + tags                               = {
          + "Name" = "ec2-private-kms-key"
        }
      + tags_all                           = {
          + "Environment" = "Test"
          + "Name"        = "ec2-private-kms-key"
          + "Project"     = "QBurst"
        }
    }

  # module.ec2-private.aws_security_group.default[0] will be created
  + resource "aws_security_group" "default" {
      + arn                    = (known after apply)
      + description            = "Instance default security group (only egress access is allowed)."
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = "ec2-private-sg"
      + name_prefix            = (known after apply)
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name" = "ec2-private-sg"
        }
      + tags_all               = {
          + "Environment" = "Test"
          + "Name"        = "ec2-private-sg"
          + "Project"     = "QBurst"
        }
      + vpc_id                 = (sensitive value)
    }

  # module.ec2-private.aws_security_group_rule.egress_ipv4[0] will be created
  + resource "aws_security_group_rule" "egress_ipv4" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "Description of the rule."
      + from_port                = 0
      + id                       = (known after apply)
      + protocol                 = "-1"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 65535
      + type                     = "egress"
    }

  # module.ec2-private.aws_security_group_rule.egress_ipv6[0] will be created
  + resource "aws_security_group_rule" "egress_ipv6" {
      + description              = "Description of the rule."
      + from_port                = 0
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = [
          + "::/0",
        ]
      + protocol                 = "-1"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 65535
      + type                     = "egress"
    }

  # module.ec2-private.aws_security_group_rule.ingress[0] will be created
  + resource "aws_security_group_rule" "ingress" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "Description of the ingress rule use elasticache."
      + from_port                = 80
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 80
      + type                     = "ingress"
    }

  # module.ec2-private.aws_security_group_rule.ingress[1] will be created
  + resource "aws_security_group_rule" "ingress" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "Description of the ingress rule use elasticache."
      + from_port                = 443
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 443
      + type                     = "ingress"
    }

  # module.ec2-private.aws_security_group_rule.ssh_ingress[0] will be created
  + resource "aws_security_group_rule" "ssh_ingress" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "Description of the ingress rule use elasticache."
      + from_port                = 22
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 22
      + type                     = "ingress"
    }

  # module.ec2-private.aws_volume_attachment.default[0] will be created
  + resource "aws_volume_attachment" "default" {
      + device_name = "/dev/xvdb"
      + id          = (known after apply)
      + instance_id = (known after apply)
      + volume_id   = (known after apply)
    }

  # module.ec2-private.tls_private_key.default[0] will be created
  + resource "tls_private_key" "default" {
      + algorithm                     = "RSA"
      + ecdsa_curve                   = "P224"
      + id                            = (known after apply)
      + private_key_openssh           = (sensitive value)
      + private_key_pem               = (sensitive value)
      + private_key_pem_pkcs8         = (sensitive value)
      + public_key_fingerprint_md5    = (known after apply)
      + public_key_fingerprint_sha256 = (known after apply)
      + public_key_openssh            = (known after apply)
      + public_key_pem                = (known after apply)
      + rsa_bits                      = 4096
    }

  # module.ec2-public.aws_eip.default[0] will be created
  + resource "aws_eip" "default" {
      + allocation_id        = (known after apply)
      + association_id       = (known after apply)
      + carrier_ip           = (known after apply)
      + customer_owned_ip    = (known after apply)
      + domain               = (known after apply)
      + id                   = (known after apply)
      + instance             = (known after apply)
      + network_border_group = (known after apply)
      + network_interface    = (known after apply)
      + private_dns          = (known after apply)
      + private_ip           = (known after apply)
      + public_dns           = (known after apply)
      + public_ip            = (known after apply)
      + public_ipv4_pool     = (known after apply)
      + tags                 = {
          + "Name" = "ec2-public-0-eip"
        }
      + tags_all             = {
          + "Environment" = "Test"
          + "Name"        = "ec2-public-0-eip"
          + "Project"     = "QBurst"
        }
      + vpc                  = (known after apply)
    }

  # module.ec2-public.aws_instance.default[0] will be created
  + resource "aws_instance" "default" {
      + ami                                  = "ami-0d906b8d7a7fbf25f"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = false
      + availability_zone                    = (known after apply)
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + disable_api_stop                     = (known after apply)
      + disable_api_termination              = false
      + ebs_optimized                        = false
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + host_resource_group_arn              = (known after apply)
      + iam_instance_profile                 = (known after apply)
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_lifecycle                   = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "t2.micro"
      + ipv6_address_count                   = (known after apply)
      + ipv6_addresses                       = (sensitive value)
      + key_name                             = "ec2-public"
      + monitoring                           = false
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + placement_partition_number           = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + secondary_private_ips                = (known after apply)
      + security_groups                      = (known after apply)
      + source_dest_check                    = true
      + spot_instance_request_id             = (known after apply)
      + subnet_id                            = (known after apply)
      + tags                                 = {
          + "Name" = "ec2-public-0"
        }
      + tags_all                             = {
          + "Environment" = "Test"
          + "Name"        = "ec2-public-0"
          + "Project"     = "QBurst"
        }
      + tenancy                              = "default"
      + user_data_base64                     = (known after apply)
      + user_data_replace_on_change          = false
      + vpc_security_group_ids               = (known after apply)
    }

  # module.ec2-public.aws_key_pair.default[0] will be created
  + resource "aws_key_pair" "default" {
      + arn             = (known after apply)
      + fingerprint     = (known after apply)
      + id              = (known after apply)
      + key_name        = "ec2-public"
      + key_name_prefix = (known after apply)
      + key_pair_id     = (known after apply)
      + key_type        = (known after apply)
      + public_key      = (known after apply)
      + tags            = {
          + "Name" = "ec2-public-key"
        }
      + tags_all        = {
          + "Environment" = "Test"
          + "Name"        = "ec2-public-key"
          + "Project"     = "QBurst"
        }
    }

  # module.ec2-public.aws_kms_alias.default[0] will be created
  + resource "aws_kms_alias" "default" {
      + arn            = (known after apply)
      + id             = (known after apply)
      + name           = "alias/ec2-public"
      + name_prefix    = (known after apply)
      + target_key_arn = (known after apply)
      + target_key_id  = (known after apply)
    }

  # module.ec2-public.aws_kms_key.default[0] will be created
  + resource "aws_kms_key" "default" {
      + arn                                = (known after apply)
      + bypass_policy_lockout_safety_check = false
      + customer_master_key_spec           = "SYMMETRIC_DEFAULT"
      + deletion_window_in_days            = 7
      + description                        = "KMS master key"
      + enable_key_rotation                = true
      + id                                 = (known after apply)
      + is_enabled                         = true
      + key_id                             = (known after apply)
      + key_usage                          = "ENCRYPT_DECRYPT"
      + multi_region                       = false
      + policy                             = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "kms:*"
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::062427305583:root"
                        }
                      + Resource  = "*"
                      + Sid       = "Enable IAM User Permissions"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + tags                               = {
          + "Name" = "ec2-public-kms-key"
        }
      + tags_all                           = {
          + "Environment" = "Test"
          + "Name"        = "ec2-public-kms-key"
          + "Project"     = "QBurst"
        }
    }

  # module.ec2-public.aws_security_group.default[0] will be created
  + resource "aws_security_group" "default" {
      + arn                    = (known after apply)
      + description            = "Instance default security group (only egress access is allowed)."
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = "ec2-public-sg"
      + name_prefix            = (known after apply)
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name" = "ec2-public-sg"
        }
      + tags_all               = {
          + "Environment" = "Test"
          + "Name"        = "ec2-public-sg"
          + "Project"     = "QBurst"
        }
      + vpc_id                 = (sensitive value)
    }

  # module.ec2-public.aws_security_group_rule.egress_ipv4[0] will be created
  + resource "aws_security_group_rule" "egress_ipv4" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "Description of the rule."
      + from_port                = 0
      + id                       = (known after apply)
      + protocol                 = "-1"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 65535
      + type                     = "egress"
    }

  # module.ec2-public.aws_security_group_rule.egress_ipv6[0] will be created
  + resource "aws_security_group_rule" "egress_ipv6" {
      + description              = "Description of the rule."
      + from_port                = 0
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = [
          + "::/0",
        ]
      + protocol                 = "-1"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 65535
      + type                     = "egress"
    }

  # module.ec2-public.aws_security_group_rule.ingress[0] will be created
  + resource "aws_security_group_rule" "ingress" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "Description of the ingress rule use elasticache."
      + from_port                = 80
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 80
      + type                     = "ingress"
    }

  # module.ec2-public.aws_security_group_rule.ingress[1] will be created
  + resource "aws_security_group_rule" "ingress" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "Description of the ingress rule use elasticache."
      + from_port                = 443
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 443
      + type                     = "ingress"
    }

  # module.ec2-public.aws_security_group_rule.ssh_ingress[0] will be created
  + resource "aws_security_group_rule" "ssh_ingress" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "Description of the ingress rule use elasticache."
      + from_port                = 8443
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 8443
      + type                     = "ingress"
    }

  # module.ec2-public.tls_private_key.default[0] will be created
  + resource "tls_private_key" "default" {
      + algorithm                     = "RSA"
      + ecdsa_curve                   = "P224"
      + id                            = (known after apply)
      + private_key_openssh           = (sensitive value)
      + private_key_pem               = (sensitive value)
      + private_key_pem_pkcs8         = (sensitive value)
      + public_key_fingerprint_md5    = (known after apply)
      + public_key_fingerprint_sha256 = (known after apply)
      + public_key_openssh            = (known after apply)
      + public_key_pem                = (known after apply)
      + rsa_bits                      = 4096
    }
.
.
.
Plan: 41 to add, 0 to change, 0 to destroy.
```